### PR TITLE
Fixes on links page

### DIFF
--- a/pages/links.markdown
+++ b/pages/links.markdown
@@ -10,7 +10,7 @@ permalink: /links/
 * Marcin Zajaczkowski maintains a Gradle plugin. [PIT Gradle plugin](http://gradle-pitest-plugin.solidsoft.info/)
 * Phil Glover maintains an Eclipse plugin. [Pitclipse](https://github.com/philglover/pitclipse)
 * Alexandre Victoor maintains a Sonar plugin. [PIT Sonar plugin](http://docs.codehaus.org/display/SONAR/Pitest)
-* Michal Jedynak maintains an Intellij plugin [PIT intellij plugin](http://plugins.intellij.net/plugin/?idea&pluginId=7119)
+* Michal Jedynak maintains an Intellij plugin. [PIT intellij plugin](http://plugins.intellij.net/plugin/?idea&pluginId=7119)
 
 ## Videos
 

--- a/pages/links.markdown
+++ b/pages/links.markdown
@@ -26,8 +26,7 @@ permalink: /links/
 * Filip van Laenen's article in the ACCU magazine *Overload* provides another nice overview of mutation testing, looking mainly at Ruby, but with
  some discussion of Java and PIT towards the end. [Overload 108](http://accu.org/var/uploads/journals/overload108.pdf)
 * The *Overload* 108 article is based on a presentation Filip van Laenen gave at OOP 2012 in Munich. The slides from that presentation can be viewed at SlideShare. [Mutation Testing](http://www.slideshare.net/filipvanlaenen/mutation-testing-11298526)
-* <span class='book'>
-<a href="http://www.amazon.com/gp/product/839348930X/ref=as_li_qf_sp_asin_il?ie=UTF8&camp=1789&creative=9325&creativeASIN=839348930X&linkCode=as2&tag=jarfinder-20"><img border="0" src="http://ws.assoc-amazon.com/widgets/q?_encoding=UTF8&ASIN=839348930X&Format=_SL110_&ID=AsinImage&MarketPlace=US&ServiceVersion=20070822&WS=1&tag=jarfinder-20" ></a><img src="http://www.assoc-amazon.com/e/ir?t=jarfinder-20&l=as2&o=1&a=839348930X" width="1" height="1" border="0" alt="" style="border:none !important; margin:0px !important;" /></span> PIT gets a mention in Tomek Kaczanowski's book "Practical Unit Testing with TestNG and Mockito".
+* PIT gets a mention in Tomek Kaczanowski's book [Practical Unit Testing with TestNG and Mockito](http://www.amazon.com/gp/product/839348930X).
 
 
 <br/>


### PR DESCRIPTION
Added missing . to keep the consistency with links the the same list
Fixed the link to Practical Unit Testing with TestNG and Mockito
