### PR TITLE
Small fix in pages/weak_tests - swapped 'bar' with 'foo' in the missing boundry test

### DIFF
--- a/pages/weak_tests.markdown
+++ b/pages/weak_tests.markdown
@@ -53,13 +53,13 @@ public static String foo(int i) {
 }
 
 @Test
-public void shouldReturnBarWhenGiven1() {
-  assertEquals("bar", foo(1));
+public void shouldReturnFooWhenGiven1() {
+  assertEquals("foo", foo(1));
 }
 
 @Test
-public void shouldReturnFooWhenGivenMinus1() {
-  assertEquals("foo", foo(-1));
+public void shouldReturnBarWhenGivenMinus1() {
+  assertEquals("bar", foo(-1));
 }
 ```
 


### PR DESCRIPTION
The current test always fails as `bar` is swapped with `foo` in this test.
