### PR TITLE
Reduce spacing between code lines

### DIFF
--- a/css/pit.css
+++ b/css/pit.css
@@ -771,6 +771,6 @@ h2 + .row {
   
 }
 
-code, table.table td {
+table.table td {
     line-height: 34px;
 }


### PR DESCRIPTION
I think code extract would look better without the spacing that is currently present between lines.

Here is how it looks with this change :
![after](https://user-images.githubusercontent.com/6149080/39664449-977cac36-5083-11e8-8a03-b97b5a1d632a.png)

Here is how it looks without it / currently :
![before](https://user-images.githubusercontent.com/6149080/39664445-934ddb3a-5083-11e8-9d55-2254c7cfe522.png)
