### PR TITLE
Add "improve this page links" to ease minor fixes

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,6 +6,10 @@ layout: naked
 <div class="col-md-12">
 
 <section>
+    <div class="improve">
+        <a href="https://github.com/hcoles/pitest-site/edit/gh-pages/{{ page.path }}">
+            <span class="glyphicon glyphicon-pencil"></span>&nbsp;Improve this page</a>
+    </div>
     {{ content }}
 </section>
 </div>

--- a/css/pit.css
+++ b/css/pit.css
@@ -24,6 +24,19 @@ h3 code {
   font-weight: normal;
 }
 
+/* "Improve this page" links
+-------------------------------------------------- */
+.improve a {
+  float: right;
+  top: 27px;
+  position: relative;
+  color: #ddd;
+}
+
+.improve a:hover {
+  color: #ccc;
+}
+
 /* Sections
 -------------------------------------------------- */
 


### PR DESCRIPTION
I noticed the "Improve this page" like the one [on this page](https://jekyllrb.com/docs/) in Jekyll website. They make it really easy to submit a typo fix. I think that this is great :smile:

This pull request propose to add this type of links on all page except on the index page (it's html, so slightly less easy to edit than markdown, and it's maybe better to keep this one more "clean").