### PR TITLE
Use markdown tables instead of html tables

### DIFF
--- a/_posts/2011-09-26-we_have_a_roadmap.markdown
+++ b/_posts/2011-09-26-we_have_a_roadmap.markdown
@@ -6,9 +6,7 @@ tags: roadmap
 layout: post
 ---
 
-Several people have asked if there is a roadmap for PIT, so with a nod to Heisenberg <a href="#fn1"><sup>1</sup></a>
-<a name="fnref1" id="fnref1"></a>
-[now we do](/roadmap/).
+Several people have asked if there is a roadmap for PIT, so with a nod to Heisenberg <sup id="fnref1">[1](#fn1)</sup> [now we do](/roadmap/).
 
 <!-- more -->
 

--- a/pages/java_mutation_testing_systems.markdown
+++ b/pages/java_mutation_testing_systems.markdown
@@ -352,176 +352,27 @@ by other tools, eg XML, RDMS etc.
 
 ### Classification and details
 
-<table class="table">
-    <thead>
-        <tr>
-            <th>System</th>
-            <th>Generation</th>
-            <th>Selection</th>
-            <th>Insertion</th>
-            <th>Detection</th>
-            <th>Output</th>
-            <th>SF</th>
-            <th>License</th>
-            <th>Mailing List</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><a href="#jester">Jester</a></td>
-            <td>Source</td>
-            <td>Naive?</td>
-            <td>Naive?</td>
-            <td>Naive?</td>
-            <td><strong>AS</strong></td>
-            <td>N</td>
-            <td>MIT</td>
-            <td>N</td>
-        </tr>
-        <tr>
-            <td><a href="#simple jester">Simple Jester</a></td>
-            <td>Source</td>
-            <td>Naive?</td>
-            <td>Naive?</td>
-            <td>Naive?</td>
-            <td><strong>AS</strong></td>
-            <td>N</td>
-            <td>MIT</td>
-            <td>N</td>
-        </tr>
-        <tr>
-            <td><a href="#jumble">Jumble</a></td>
-            <td>BCEL</td>
-            <td>Convention</td>
-            <td>NDClassloader</td>
-            <td><strong>EE Fine</strong></td>
-            <td>T</td>
-            <td>N</td>
-            <td>APCH2</td>
-            <td><strong>Y</strong><a name="fnref4" id="fnref4"></a> <a href="#fn4"><sup>4</sup></a>.</td>
-        </tr>
-        <tr>
-            <td><a href="#pit">PIT</a></td>
-            <td>ASM</td>
-            <td><strong>Coverage</strong></td>
-            <td>Instrument</td>
-            <td><strong>EE Fine</strong></td>
-            <td><strong>AS</strong></td>
-            <td><strong>Y</strong></td>
-            <td>APCH2</td>
-            <td><strong>Y</strong><a name="fnref5" id="fnref5"></a> <a href="#fn5"><sup>5</sup></a>.</td>
-        </tr>
-        <tr>
-            <td><a href="#&micro;Java">&micro;Java</a></td>
-            <td>Source?</td>
-            <td>Manual</td>
-            <td>N/A</td>
-            <td>N/A</td>
-            <td><strong>AS</strong></td>
-            <td>N</td>
-            <td>?</td>
-            <td>N</td>
-        </tr>
-        <tr>
-            <td><a href="#javaLanche">javaLanche</a></td>
-            <td>ASM</td>
-            <td><strong>Coverage</strong></td>
-            <td>Schemata</td>
-            <td>EE Fine?</td>
-            <td>P</td>
-            <td><strong>Y</strong></td>
-            <td>LGPL</td>
-            <td>N</td>
-        </tr>
-    </tbody>
-</table>
-
+| System                          | Generation | Selection    | Insertion     | Detection   | Output | SF    | License | Mailing List                                                            |
+|---------------------------------|------------|--------------|---------------|-------------|--------|-------|---------|-------------------------------------------------------------------------|
+| [Jester](#jester)               | Source     | Naive ?      | Naive ?       | Naive ?     | **AS** | N     | MIT     | N                                                                       |
+| [Simple Jester](#simple jester) | Source     | Naive ?      | Naive ?       | Naive ?     | **AS** | N     | MIT     | N                                                                       |
+| [Jumble](#jumble)               | BCEL       | Convention   | NDClassloader | **EE Fine** | T      | N     | APCH2   | **Y** <a name="fnref4" id="fnref4"></a> <a href="#fn4"><sup>4</sup></a>. |
+| [PIT](#pit)                     | ASM        | **Coverage** | Instrument    | **EE Fine** | **AS** | **Y** | APCH2   | **Y** <a name="fnref5" id="fnref5"></a> <a href="#fn5"><sup>5</sup></a>. |
+| [µJava](#&micro;Java)           | Source ?   | Manual       | N/A           | N/A         | **AS** | N     | ?       | N                                                                       |
+| [javaLanche](#javaLanche)       | ASM        | **Coverage** | Schemata      | EE Fine ?   | P      | **Y** | LGPL    | N                                                                       |
+{:.table}
 
 ### Java and Test framework support
 
-<table class="table">
-    <thead>
-        <tr>
-            <th>System</th>
-            <th>1.4</th>
-            <th>1.5</th>
-            <th>1.6</th>
-            <th>1.7</th>
-            <th>1.8</th>
-            <th>JUnit3</th>
-            <th>JUnit4</th>
-            <th>TestNG</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><a href="#jester">Jester</a></td>
-            <td>N</td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-            <td>N</td>
-            <td>N</td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-            <td>N</td>
-        </tr>
-        <tr>
-            <td><a href="#simple jester">Simple Jester</a></td>
-            <td>N</td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-            <td>N</td>
-            <td>N</td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-            <td>N</td>
-        </tr>
-        <tr>
-            <td><a href="#jumble">Jumble</a></td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-            <td>?</td>
-            <td>?</td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-            <td>N</td>
-        </tr>
-        <tr>
-            <td><a href="#pit">PIT</a></td>
-            <td>N</td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-        </tr>
-        <tr>
-            <td><a href="#&micro;Java">&micro;Java</a></td>
-            <td><strong>Y</strong></td>
-            <td>N</td>
-            <td>N</td>
-            <td>N</td>
-            <td>N</td>
-            <td>N</td>
-            <td>N</td>
-            <td>N</td>
-        </tr>
-        <tr>
-            <td><a href="#javaLanche">javaLanche</a></td>
-            <td>N</td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-            <td>?</td>
-            <td>?</td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-            <td>N</td>
-        </tr>
-    </tbody>
-</table>
+| System                          | 1.4 | 1.5 | 1.6 | 1.7 | 1.8 | JUnit3 | JUnit4 | TestNG |
+|---------------------------------|-----|-----|-----|-----|-----|--------|--------|--------|
+| [Jester](#jester)               | N   |**Y**|**Y**| N   | N   |**Y**   |**Y**   | N      |
+| [Simple Jester](#simple jester) | N   |**Y**|**Y**| N   | N   |**Y**   |**Y**   | N      |
+| [Jumble](#jumble)               |**Y**|**Y**|**Y**| ?   | ?   |**Y**   |**Y**   | N      |
+| [PIT](#pit)                     | N   |**Y**|**Y**|**Y**|**Y**|**Y**   |**Y**   |**Y**   |
+| [µJava](#&micro;Java)           |**Y**| N   | N   | N   | N   | N      | N      | N      |
+| [javaLanche](#javaLanche)       | N   |**Y**|**Y**| ?   | ?   |**Y**   |**Y**   | N      |
+{:.table}
 
 ### Tool integration
 
@@ -534,96 +385,15 @@ by other tools, eg XML, RDMS etc.
 *note that with the exception of PIT little information is available on the compatibility of the various mutation testing systems and
 mocking frameworks. Most mocking systems are implemented with dynamic proxies or custom class loaders, and will probably work across all the mutation testing sytems. The exceptions are Powermock and JMockit where issues might be encountered.*
 
-<table class="table">
-    <thead>
-        <tr>
-            <th>System</th>
-            <th>Ant</th>
-            <th>Maven</th>
-            <th>Eclipse</th>
-            <th>Powermock</th>
-            <th>JMock</th>
-            <th>JMock2</th>
-            <th>Mockito</th>
-            <th>JMockit</th>
-            <th>EasyMock</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><a href="#jester">Jester</a></td>
-            <td>N</td>
-            <td>N</td>
-            <td>N</td>
-            <td>?</td>
-            <td>?</td>
-            <td>?</td>
-            <td>?</td>
-            <td>?</td>
-            <td>?</td>
-        </tr>
-        <tr>
-            <td><a href="#simple jester">Simple Jester</a></td>
-            <td>N</td>
-            <td>N</td>
-            <td>N</td>
-            <td>?</td>
-            <td>?</td>
-            <td>?</td>
-            <td>?</td>
-            <td>?</td>
-            <td>?</td>
-        </tr>
-        <tr>
-            <td><a href="#jumble">Jumble</a></td>
-            <td><strong>Y</strong></td>
-            <td>N</td>
-            <td><strong>Y</strong></td>
-            <td>?</td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-            <td>N<a name="fnref6" id="fnref6"></a> <a href="#fn6"><sup>6</sup></a>.</td>
-            <td>?</td>
-        </tr>
-        <tr>
-            <td><a href="#pit">PIT</a></td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-            <td>3rd</td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-            <td><strong>Y</strong></td>
-        </tr>
-        <tr>
-            <td><a href="#&micro;Java">&micro;Java</a></td>
-            <td>N</td>
-            <td>N</td>
-            <td>3rd <a name="fnref7" id="fnref7"></a> <a href="#fn7"><sup>7</sup></a>.</td>
-            <td>?</td>
-            <td>?</td>
-            <td>?</td>
-            <td>?</td>
-            <td>?</td>
-            <td>?</td>
-        </tr>
-        <tr>
-            <td><a href="#javaLanche">javaLanche</a></td>
-            <td>N</td>
-            <td>N</td>
-            <td>N</td>
-            <td>?</td>
-            <td>?</td>
-            <td>?</td>
-            <td>?</td>
-            <td>N<a name="fnref8" id="fnref8"></a> <a href="#fn8"><sup>8</sup></a>.</td>
-            <td>! <a name="fnref9" id="fnref9"></a> <a href="#fn9"><sup>9</sup></a>.</td>
-        </tr>
-    </tbody>
-</table>
+| System                          | Ant | Maven | Eclipse                                                               | Powermock | JMock | JMock2 | Mockito | JMockit                                                              | EasyMock                                                            |
+|---------------------------------|-----|-------|-----------------------------------------------------------------------|-----------|-------|--------|---------|----------------------------------------------------------------------|---------------------------------------------------------------------|
+| [Jester](#jester)               | N   | N     | N                                                                     | ?         | ?     | ?      | ?       | ?                                                                    | ?                                                                   |   
+| [Simple Jester](#simple jester) | N   | N     | N                                                                     | ?         | ?     | ?      | ?       | ?                                                                    | ?                                                                   |
+| [Jumble](#jumble)               |**Y**| N     | **Y**                                                                 | ?         | **Y** | **Y**  | **Y**   | N <a name="fnref6" id="fnref6"></a> <a href="#fn6"><sup>6</sup></a>. | ?                                                                   |
+| [PIT](#pit)                     |**Y**|**Y**  | 3rd                                                                   | **Y**     | **Y** | **Y**  | **Y**   | **Y**                                                                | **Y**                                                               |
+| [µJava](#&micro;Java)           | N   | N     | 3rd <a name="fnref7" id="fnref7"></a> <a href="#fn7"><sup>7</sup></a> | ?         | ?     | ?      | ?       | ?                                                                    | ?                                                                   |
+| [javaLanche](#javaLanche)       | N   | N     | N                                                                     | ?         | ?     | ?      | ?       | N <a name="fnref8" id="fnref8"></a> <a href="#fn8"><sup>8</sup></a>. | ! <a name="fnref9" id="fnref9"></a> <a href="#fn9"><sup>9</sup></a>.|
+{:.table}
 
 # Conclusions
 

--- a/pages/java_mutation_testing_systems.markdown
+++ b/pages/java_mutation_testing_systems.markdown
@@ -42,7 +42,7 @@ Jester was the first open source mutation system for Java, but does not appear t
 
 WebSite : [http://jester.sourceforge.net/](http://jester.sourceforge.net/)
 
-Simple Jester is a variant of the original Jester by the same author who describes it as easier to use, but slower <a name="fnref1" id="fnref1"></a> <a href="#fn1"><sup>1</sup></a>.
+Simple Jester is a variant of the original Jester by the same author who describes it as easier to use, but slower <sup id="fnref1">[1]((#fn1))</sup>.
 
 It appears to no longer be actively developed or supported.
 
@@ -131,7 +131,7 @@ Of these libraries, BCEL is no longer actively developed or maintained.
 * Generally much faster
 * Generally easier to integrate into a build
 * Can potentially create mutants without access to source files
-* Same mutation operators can in theory work for other JVM languages <a name="fnref2" id="fnref2"></a> <a href="#fn2"><sup>2</sup></a>
+* Same mutation operators can in theory work for other JVM languages <sup id="fnref2">[2](#fn2)</sup>
 
 #### Cons
 
@@ -203,7 +203,7 @@ Optimisations may also be implemented to choose an optimal running order for the
 
 #### Cons
 
-* Some overhead required to measure coverage <a name="fnref3" id="fnref3"></a> <a href="#fn3"><sup>3</sup></a>.
+* Some overhead required to measure coverage <sup id="fnref3">[3](#fn3)</sup>.
 
 ## Mutant insertion
 
@@ -352,14 +352,14 @@ by other tools, eg XML, RDMS etc.
 
 ### Classification and details
 
-| System                          | Generation | Selection    | Insertion     | Detection   | Output | SF    | License | Mailing List                                                            |
-|---------------------------------|------------|--------------|---------------|-------------|--------|-------|---------|-------------------------------------------------------------------------|
-| [Jester](#jester)               | Source     | Naive ?      | Naive ?       | Naive ?     | **AS** | N     | MIT     | N                                                                       |
-| [Simple Jester](#simple-jester) | Source     | Naive ?      | Naive ?       | Naive ?     | **AS** | N     | MIT     | N                                                                       |
-| [Jumble](#jumble)               | BCEL       | Convention   | NDClassloader | **EE Fine** | T      | N     | APCH2   | **Y** <a name="fnref4" id="fnref4"></a> <a href="#fn4"><sup>4</sup></a>. |
-| [PIT](#pit)                     | ASM        | **Coverage** | Instrument    | **EE Fine** | **AS** | **Y** | APCH2   | **Y** <a name="fnref5" id="fnref5"></a> <a href="#fn5"><sup>5</sup></a>. |
-| [µJava](#µjava)                 | Source ?   | Manual       | N/A           | N/A         | **AS** | N     | ?       | N                                                                       |
-| [javaLanche](#javalanche)       | ASM        | **Coverage** | Schemata      | EE Fine ?   | P      | **Y** | LGPL    | N                                                                       |
+| System                          | Generation | Selection    | Insertion     | Detection   | Output | SF    | License | Mailing List                            |
+|---------------------------------|------------|--------------|---------------|-------------|--------|-------|---------|-----------------------------------------|
+| [Jester](#jester)               | Source     | Naive ?      | Naive ?       | Naive ?     | **AS** | N     | MIT     | N                                       |
+| [Simple Jester](#simple-jester) | Source     | Naive ?      | Naive ?       | Naive ?     | **AS** | N     | MIT     | N                                       |
+| [Jumble](#jumble)               | BCEL       | Convention   | NDClassloader | **EE Fine** | T      | N     | APCH2   | **Y** <sup id="fnref4">[4](#fn4)</sup>. |
+| [PIT](#pit)                     | ASM        | **Coverage** | Instrument    | **EE Fine** | **AS** | **Y** | APCH2   | **Y** <sup id="fnref5">[5](#fn5)</sup>. |
+| [µJava](#µjava)                 | Source ?   | Manual       | N/A           | N/A         | **AS** | N     | ?       | N                                       |
+| [javaLanche](#javalanche)       | ASM        | **Coverage** | Schemata      | EE Fine ?   | P      | **Y** | LGPL    | N                                       |
 {:.table}
 
 ### Java and Test framework support
@@ -385,14 +385,14 @@ by other tools, eg XML, RDMS etc.
 *note that with the exception of PIT little information is available on the compatibility of the various mutation testing systems and
 mocking frameworks. Most mocking systems are implemented with dynamic proxies or custom class loaders, and will probably work across all the mutation testing sytems. The exceptions are Powermock and JMockit where issues might be encountered.*
 
-| System                          | Ant | Maven | Eclipse                                                               | Powermock | JMock | JMock2 | Mockito | JMockit                                                               | EasyMock                                                            |
-|---------------------------------|-----|-------|-----------------------------------------------------------------------|-----------|-------|--------|---------|-----------------------------------------------------------------------|---------------------------------------------------------------------|
-| [Jester](#jester)               | N   | N     | N                                                                     | ?         | ?     | ?      | ?       | ?                                                                     | ?                                                                   |   
-| [Simple Jester](#simple-jester) | N   | N     | N                                                                     | ?         | ?     | ?      | ?       | ?                                                                     | ?                                                                   |
-| [Jumble](#jumble)               |**Y**| N     | **Y**                                                                 | ?         | **Y** | **Y**  | **Y**   | N <a name="fnref6" id="fnref6"></a> <a href="#fn6"><sup>6</sup></a>.  | ?                                                                   |
-| [PIT](#pit)                     |**Y**|**Y**  | 3rd                                                                   | **Y**     | **Y** | **Y**  | **Y**   | **Y**                                                                 | **Y**                                                               |
-| [µJava](#µjava)                 | N   | N     | 3rd <a name="fnref7" id="fnref7"></a> <a href="#fn7"><sup>7</sup></a> | ?         | ?     | ?      | ?       | ?                                                                     | ?                                                                   |
-| [javaLanche](#javalanche)       | N   | N     | N                                                                     | ?         | ?     | ?      | ?       | N <a name="fnref8" id="fnref8"></a> <a href="#fn8"><sup>8</sup></a>.  | ! <a name="fnref9" id="fnref9"></a> <a href="#fn9"><sup>9</sup></a>.|
+| System                          | Ant | Maven | Eclipse                              | Powermock | JMock | JMock2 | Mockito | JMockit                             | EasyMock                           |
+|---------------------------------|-----|-------|--------------------------------------|-----------|-------|--------|---------|-------------------------------------|------------------------------------|
+| [Jester](#jester)               | N   | N     | N                                    | ?         | ?     | ?      | ?       | ?                                   | ?                                  |   
+| [Simple Jester](#simple-jester) | N   | N     | N                                    | ?         | ?     | ?      | ?       | ?                                   | ?                                  |
+| [Jumble](#jumble)               |**Y**| N     | **Y**                                | ?         | **Y** | **Y**  | **Y**   | N <sup id="fnref6">[6](#fn6)</sup>. | ?                                  |
+| [PIT](#pit)                     |**Y**|**Y**  | 3rd                                  | **Y**     | **Y** | **Y**  | **Y**   | **Y**                               | **Y**                              |
+| [µJava](#µjava)                 | N   | N     | 3rd <sup id="fnref7">[7](#fn7)</sup> | ?         | ?     | ?      | ?       | ?                                   | ?                                  |
+| [javaLanche](#javalanche)       | N   | N     | ?                                    | ?         | ?     | ?      | ?       | N <sup id="fnref8">[8](#fn8)</sup>. | ! <sup id="fnref9">[9](#fn9)</sup>.|
 {:.table}
 
 # Conclusions

--- a/pages/java_mutation_testing_systems.markdown
+++ b/pages/java_mutation_testing_systems.markdown
@@ -355,11 +355,11 @@ by other tools, eg XML, RDMS etc.
 | System                          | Generation | Selection    | Insertion     | Detection   | Output | SF    | License | Mailing List                                                            |
 |---------------------------------|------------|--------------|---------------|-------------|--------|-------|---------|-------------------------------------------------------------------------|
 | [Jester](#jester)               | Source     | Naive ?      | Naive ?       | Naive ?     | **AS** | N     | MIT     | N                                                                       |
-| [Simple Jester](#simple jester) | Source     | Naive ?      | Naive ?       | Naive ?     | **AS** | N     | MIT     | N                                                                       |
+| [Simple Jester](#simple-jester) | Source     | Naive ?      | Naive ?       | Naive ?     | **AS** | N     | MIT     | N                                                                       |
 | [Jumble](#jumble)               | BCEL       | Convention   | NDClassloader | **EE Fine** | T      | N     | APCH2   | **Y** <a name="fnref4" id="fnref4"></a> <a href="#fn4"><sup>4</sup></a>. |
 | [PIT](#pit)                     | ASM        | **Coverage** | Instrument    | **EE Fine** | **AS** | **Y** | APCH2   | **Y** <a name="fnref5" id="fnref5"></a> <a href="#fn5"><sup>5</sup></a>. |
-| [µJava](#&micro;Java)           | Source ?   | Manual       | N/A           | N/A         | **AS** | N     | ?       | N                                                                       |
-| [javaLanche](#javaLanche)       | ASM        | **Coverage** | Schemata      | EE Fine ?   | P      | **Y** | LGPL    | N                                                                       |
+| [µJava](#µjava)                 | Source ?   | Manual       | N/A           | N/A         | **AS** | N     | ?       | N                                                                       |
+| [javaLanche](#javalanche)       | ASM        | **Coverage** | Schemata      | EE Fine ?   | P      | **Y** | LGPL    | N                                                                       |
 {:.table}
 
 ### Java and Test framework support
@@ -367,11 +367,11 @@ by other tools, eg XML, RDMS etc.
 | System                          | 1.4 | 1.5 | 1.6 | 1.7 | 1.8 | JUnit3 | JUnit4 | TestNG |
 |---------------------------------|-----|-----|-----|-----|-----|--------|--------|--------|
 | [Jester](#jester)               | N   |**Y**|**Y**| N   | N   |**Y**   |**Y**   | N      |
-| [Simple Jester](#simple jester) | N   |**Y**|**Y**| N   | N   |**Y**   |**Y**   | N      |
+| [Simple Jester](#simple-jester) | N   |**Y**|**Y**| N   | N   |**Y**   |**Y**   | N      |
 | [Jumble](#jumble)               |**Y**|**Y**|**Y**| ?   | ?   |**Y**   |**Y**   | N      |
 | [PIT](#pit)                     | N   |**Y**|**Y**|**Y**|**Y**|**Y**   |**Y**   |**Y**   |
-| [µJava](#&micro;Java)           |**Y**| N   | N   | N   | N   | N      | N      | N      |
-| [javaLanche](#javaLanche)       | N   |**Y**|**Y**| ?   | ?   |**Y**   |**Y**   | N      |
+| [µJava](#µjava)                 |**Y**| N   | N   | N   | N   | N      | N      | N      |
+| [javaLanche](#javalanche)       | N   |**Y**|**Y**| ?   | ?   |**Y**   |**Y**   | N      |
 {:.table}
 
 ### Tool integration
@@ -385,14 +385,14 @@ by other tools, eg XML, RDMS etc.
 *note that with the exception of PIT little information is available on the compatibility of the various mutation testing systems and
 mocking frameworks. Most mocking systems are implemented with dynamic proxies or custom class loaders, and will probably work across all the mutation testing sytems. The exceptions are Powermock and JMockit where issues might be encountered.*
 
-| System                          | Ant | Maven | Eclipse                                                               | Powermock | JMock | JMock2 | Mockito | JMockit                                                              | EasyMock                                                            |
-|---------------------------------|-----|-------|-----------------------------------------------------------------------|-----------|-------|--------|---------|----------------------------------------------------------------------|---------------------------------------------------------------------|
-| [Jester](#jester)               | N   | N     | N                                                                     | ?         | ?     | ?      | ?       | ?                                                                    | ?                                                                   |   
-| [Simple Jester](#simple jester) | N   | N     | N                                                                     | ?         | ?     | ?      | ?       | ?                                                                    | ?                                                                   |
-| [Jumble](#jumble)               |**Y**| N     | **Y**                                                                 | ?         | **Y** | **Y**  | **Y**   | N <a name="fnref6" id="fnref6"></a> <a href="#fn6"><sup>6</sup></a>. | ?                                                                   |
-| [PIT](#pit)                     |**Y**|**Y**  | 3rd                                                                   | **Y**     | **Y** | **Y**  | **Y**   | **Y**                                                                | **Y**                                                               |
-| [µJava](#&micro;Java)           | N   | N     | 3rd <a name="fnref7" id="fnref7"></a> <a href="#fn7"><sup>7</sup></a> | ?         | ?     | ?      | ?       | ?                                                                    | ?                                                                   |
-| [javaLanche](#javaLanche)       | N   | N     | N                                                                     | ?         | ?     | ?      | ?       | N <a name="fnref8" id="fnref8"></a> <a href="#fn8"><sup>8</sup></a>. | ! <a name="fnref9" id="fnref9"></a> <a href="#fn9"><sup>9</sup></a>.|
+| System                          | Ant | Maven | Eclipse                                                               | Powermock | JMock | JMock2 | Mockito | JMockit                                                               | EasyMock                                                            |
+|---------------------------------|-----|-------|-----------------------------------------------------------------------|-----------|-------|--------|---------|-----------------------------------------------------------------------|---------------------------------------------------------------------|
+| [Jester](#jester)               | N   | N     | N                                                                     | ?         | ?     | ?      | ?       | ?                                                                     | ?                                                                   |   
+| [Simple Jester](#simple-jester) | N   | N     | N                                                                     | ?         | ?     | ?      | ?       | ?                                                                     | ?                                                                   |
+| [Jumble](#jumble)               |**Y**| N     | **Y**                                                                 | ?         | **Y** | **Y**  | **Y**   | N <a name="fnref6" id="fnref6"></a> <a href="#fn6"><sup>6</sup></a>.  | ?                                                                   |
+| [PIT](#pit)                     |**Y**|**Y**  | 3rd                                                                   | **Y**     | **Y** | **Y**  | **Y**   | **Y**                                                                 | **Y**                                                               |
+| [µJava](#µjava)                 | N   | N     | 3rd <a name="fnref7" id="fnref7"></a> <a href="#fn7"><sup>7</sup></a> | ?         | ?     | ?      | ?       | ?                                                                     | ?                                                                   |
+| [javaLanche](#javalanche)       | N   | N     | N                                                                     | ?         | ?     | ?      | ?       | N <a name="fnref8" id="fnref8"></a> <a href="#fn8"><sup>8</sup></a>.  | ! <a name="fnref9" id="fnref9"></a> <a href="#fn9"><sup>9</sup></a>.|
 {:.table}
 
 # Conclusions

--- a/quickstart/mutators.markdown
+++ b/quickstart/mutators.markdown
@@ -359,10 +359,10 @@ are converted to byte code.
 | Constant Type            | Mutation
 |--------------------------|---
 | `boolean`                | replace the unmutated value `true` with `false` and replace the unmutated value `false` with `true`
-| `integer` `byte` `short` | replace the unmutated value `1` with `0`, `-1` with `1`, `5` with `-1` or otherwise increment the unmutated value by one. <a href="#fn1"><sup>1</sup></a> <a name="fnref1" id="fnref1"></a>
+| `integer` `byte` `short` | replace the unmutated value `1` with `0`, `-1` with `1`, `5` with `-1` or otherwise increment the unmutated value by one. <sup id="fnref1">[1](#fn1)</sup>
 | `long`                   | replace the unmutated value `1` with `0`, otherwise increment the unmutated value by one.
-| `float`                  | replace the unmutated values `1.0` and `2.0` with `0.0` and replace any other value with `1.0` <a href="#fn2"><sup>2</sup></a> <a name="fnref2" id="fnref2"></a>
-| `double`                 | replace the unmutated value `1.0` with `0.0` and replace any other value with `1.0` <a href="#fn3"><sup>3</sup></a> <a name="fnref3" id="fnref3"></a>
+| `float`                  | replace the unmutated values `1.0` and `2.0` with `0.0` and replace any other value with `1.0` <sup id="fnref2">[2](#fn2)</sup>
+| `double`                 | replace the unmutated value `1.0` with `0.0` and replace any other value with `1.0` <sup id="fnref3">[3](#fn3)</sup>
 {:.table}
 
 
@@ -419,7 +419,7 @@ Return Values Mutator (RETURN_VALS)
 **Active by default**
 
 The return values mutator mutates the return values of method calls. Depending
-on the return type of the method another mutation is used.<a href="#fn4"><sup>4</sup></a> <a name="fnref4" id="fnref4"></a>
+on the return type of the method another mutation is used.<sup id="fnref4">[4](#fn4)</sup></a>
 
 | Return Type          | Mutation 
 |----------------------|---

--- a/quickstart/mutators.markdown
+++ b/quickstart/mutators.markdown
@@ -54,36 +54,13 @@ The conditionals boundary mutator replaces the relational operators `<, <=, >, >
 
 with their boundary counterpart as per the table below.
 
-<table class="table">
-    <thead>
-        <tr>
-            <th>
-            Original conditional
-            </th>
-            <th>
-            Mutated conditional
-            </th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>&lt;</td>
-            <td>&lt;=</td>
-        </tr>
-        <tr>
-            <td>&lt;=</td>
-            <td>&lt;</td>
-        </tr>
-        <tr>
-            <td>&gt;</td>
-            <td>&gt;=</td>
-        </tr>
-        <tr>
-            <td>&gt;=</td>
-            <td>&gt;</td>
-        </tr>
-    </tbody>
-</table>
+| Original conditional | Mutated conditional |
+|----------------------|---------------------|
+| <                    | <=                  |
+| <=                   | <                   |
+| \>                   | \>=                 |
+| \>=                  | \>                  |
+{:.table }
 
 For example
 
@@ -111,45 +88,15 @@ Negate Conditionals Mutator (NEGATE_CONDITIONALS)
 The negate conditionals mutator will mutate all conditionals found according
 to the replacement table below.
 
-<table class="table">
-    <thead>
-        <tr>
-            <th>
-            Original conditional
-            </th>
-            <th>
-            Mutated conditional
-            </th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>==</td>
-            <td>!=</td>
-        </tr>
-        <tr>
-            <td>!=</td>
-            <td>==</td>
-        </tr>
-        <tr>
-            <td>&lt;=</td>
-            <td>&gt;</td>
-        </tr>
-        <tr>
-            <td>&gt;=</td>
-            <td>&lt;</td>
-        </tr>
-        <tr>
-            <td>&lt;</td>
-            <td>&gt;=</td>
-        </tr>
-        <tr>
-            <td>&gt;</td>
-            <td>&lt;=</td>
-        </tr>
-
-    </tbody>
-</table>
+| Original conditional | Mutated conditional |
+|----------------------|---------------------|
+| ==                   | !=                  |
+| !=                   | ==                  |
+| <=                   | \>                  |
+| \>=                  | <                   |
+| <                    | \>=                 |
+| \>                   | <=                  |
+{:.table }
 
 For example
 
@@ -260,64 +207,20 @@ The math mutator replaces binary arithmetic operations for either integer or
 floating-point arithmetic with another operation. The replacements will be 
 selected according to the table below.
 
-<table class="table">
-    <thead>
-        <tr>
-            <th>
-            Original conditional
-            </th>
-            <th>
-            Mutated conditional
-            </th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>+</td>
-            <td>-</td>
-        </tr>
-        <tr>
-            <td>-</td>
-            <td>+</td>
-        </tr>
-        <tr>
-            <td>*</td>
-            <td>/</td>
-        </tr>
-        <tr>
-            <td>/</td>
-            <td>*</td>
-        </tr>
-        <tr>
-            <td>%</td>
-            <td>*</td>
-        </tr>
-        <tr>
-            <td>&amp;</td>
-            <td>|</td>
-        </tr>
-        <tr>
-            <td>|</td>
-            <td>&amp;</td>
-        </tr>
-        <tr>
-            <td>^</td>
-            <td>&amp;</td>
-        </tr>
-        <tr>
-            <td>&lt;&lt;</td>
-            <td>&gt;&gt;</td>
-        </tr>
-        <tr>
-            <td>&gt;&gt;</td>
-            <td>&lt;&lt;</td>
-        </tr>
-        <tr>
-            <td>&gt;&gt;&gt;</td>
-            <td>&lt;&lt;</td>
-        </tr>
-    </tbody>
-</table>
+| Original conditional | Mutated conditional |
+|----------------------|---------------------|
+| \+                   | \-                  |
+| \-                   | \+                  |
+| *                    | /                   |
+| /                    | *                   |
+| %                    | *                   |
+| &                    | \|                  |
+| \|                   | &                   |
+| ^                    | &                   |
+| \<<                  | \>>                 |
+| \>>                  | \<<                 |
+| \>>>                 | \<<                 |
+{:.table}
 
 
 For example
@@ -453,53 +356,15 @@ Depending on the type of the inline constant another mutation is used. The rules
 are a little complex due to the different ways that apparently similar Java statements
 are converted to byte code.
 
+| Constant Type            | Mutation
+|--------------------------|---
+| `boolean`                | replace the unmutated value `true` with `false` and replace the unmutated value `false` with `true`
+| `integer` `byte` `short` | replace the unmutated value `1` with `0`, `-1` with `1`, `5` with `-1` or otherwise increment the unmutated value by one. <a href="#fn1"><sup>1</sup></a> <a name="fnref1" id="fnref1"></a>
+| `long`                   | replace the unmutated value `1` with `0`, otherwise increment the unmutated value by one.
+| `float`                  | replace the unmutated values `1.0` and `2.0` with `0.0` and replace any other value with `1.0` <a href="#fn2"><sup>2</sup></a> <a name="fnref2" id="fnref2"></a>
+| `double`                 | replace the unmutated value `1.0` with `0.0` and replace any other value with `1.0` <a href="#fn3"><sup>3</sup></a> <a name="fnref3" id="fnref3"></a>
+{:.table}
 
-<table class="table">
-    <thead>
-        <tr>
-            <th>Constant Type</th>
-            <th>Mutation</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><code>boolean</code></td>
-            <td>
-                replace the unmutated value <code>true</code> with <code>false</code> and
-                replace the unmutated value <code>false</code> with <code>true</code>
-            </td>
-        </tr>
-        <tr>
-            <td><code>integer</code> <code>byte</code> <code>short</code></td>
-            <td>
-                replace the unmutated value <code>1</code> with <code>0</code>,
-                <code>-1</code> with <code>1</code>, <code>5</code> with <code>-1</code>
-                or otherwise increment the unmutated value by one. <a href="#fn1"><sup>1</sup></a> <a name="fnref1" id="fnref1"></a>
-            </td>
-        </tr>
-        <tr>
-            <td><code>long</code></td>
-            <td>
-                replace the unmutated value <code>1</code> with <code>0</code>, otherwise
-                increment the unmutated value by one.
-            </td>
-        </tr>
-        <tr>
-            <td><code>float</code></td>
-            <td>
-                replace the unmutated values <code>1.0</code> and <code>2.0</code>
-                with <code>0.0</code> and replace any other value with <code>1.0</code> <a href="#fn2"><sup>2</sup></a> <a name="fnref2" id="fnref2"></a>
-            </td>
-        </tr>
-        <tr>
-            <td><code>double</code></td>
-            <td>
-                replace the unmutated value <code>1.0</code> with <code>0.0</code>
-                and replace any other value with <code>1.0</code> <a href="#fn3"><sup>3</sup></a> <a name="fnref3" id="fnref3"></a>
-            </td>
-        </tr>
-    </tbody>
-</table>
 
 For example
 
@@ -556,52 +421,14 @@ Return Values Mutator (RETURN_VALS)
 The return values mutator mutates the return values of method calls. Depending
 on the return type of the method another mutation is used.<a href="#fn4"><sup>4</sup></a> <a name="fnref4" id="fnref4"></a>
 
-<table class="table">
-    <thead>
-        <tr>
-            <th>Return Type</th>
-            <th>Mutation</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><code>boolean</code></td>
-            <td>
-                replace the unmutated return value <code>true</code> with <code>false</code> and
-                replace the unmutated return value <code>false</code> with <code>true</code>
-            </td>
-        </tr>
-        <tr>
-            <td><code>int</code> <code>byte</code> <code>short</code></td>
-            <td>
-                if the unmutated return value is <code>0</code> return <code>1</code>, otherwise
-                mutate to return value <code>0</code>
-            </td>
-        </tr>
-        <tr>
-            <td><code>long</code></td>
-            <td>
-                replace the unmutated return value <code>x</code> with the result of <code>x+1</code>
-            </td>
-        </tr>
-        <tr>
-            <td><code>float</code> <code>double</code></td>
-            <td>
-                replace the unmutated return value <code>x</code> with the result of
-                <code>-(x+1.0)</code> if <code>x</code> is not <code>NAN</code> and
-                replace <code>NAN</code> with <code>0</code>
-            </td>
-        </tr>
-        <tr>
-            <td><code>Object</code></td>
-            <td>
-                replace non-<code>null</code> return values with <code>null</code> and throw a
-                <code>java.lang.RuntimeException</code> if the unmutated method
-                would return <code>null</code>
-            </td>
-        </tr>
-    </tbody>
-</table>
+| Return Type          | Mutation 
+|----------------------|---
+| `boolean`            | replace the unmutated return value `true` with `false` and replace the unmutated return value `false` with `true`
+| `int` `byte` `short` | if the unmutated return value is `0` return `1`, otherwise mutate to return value `0`
+| `long`               | replace the unmutated return value `x` with the result of `x+1`
+| `float` `double`     | replace the unmutated return value `x` with the result of `-(x+1.0)` if `x` is not `NAN` and replace `NAN` with `0`
+| `Object`             | replace non-`null` return values with `null` and throw a `java.lang.RuntimeException` if the unmutated method would return `null`
+{:.table}
 
 For example
 
@@ -729,37 +556,14 @@ type. See the table below.
 
 Table: Java Default Values for Primitives and Reference Types
 
-
-<table class="table">
-    <thead>
-        <tr>
-            <th>Type</th>
-            <th>Default Value</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><code>boolean</code></td>
-            <td><code>false</code></td>
-        </tr>
-        <tr>
-            <td><code>int</code> <code>byte</code> <code>short</code> <code>long</code></td>
-            <td><code>0</code></td>
-        </tr>
-        <tr>
-            <td><code>float</code> <code>double</code></td>
-            <td><code>0.0</code></td>
-        </tr>
-        <tr>
-            <td><code>char</code></td>
-            <td><code>'\u0000'</code></td>
-        </tr>
-        <tr>
-            <td><code>Object</code></td>
-            <td><code>null</code></td>
-        </tr>
-    </tbody>
-</table>
+| Type                        | Default value |
+|-----------------------------|---------------|
+| `boolean`                   | `false`       |
+| `int` `byte` `short` `long` | `0`           |
+| `float` `double`            | `0.0`         |
+| `char`                      | `'\u0000'`    |
+| `Object`                    | `null`        |
+{:.table}
 
 For example
 
@@ -866,50 +670,15 @@ type. See the table below.
 
 Table: Java Default Values for Primitives and Reference Types
 
-<table class="table">
-    <thead>
-        <tr>
-            <th>Type</th>
-            <th>Default Value</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>
-                <code>boolean</code>
-            </td>
-            <td>`false`</td>
-        </tr>
-        <tr>
-            <td>
-                <code>int</code>
-                <code>short</code>
-                <code>byte</code>
-                <code>long</code>
-            </td>
-            <td>`0`</td>
-        </tr>
-        <tr>
-            <td>
-                <code>float</code>
-                <code>double</code>
-            </td>
-            <td>`0.0`</td>
-        </tr>
-        <tr>
-            <td>
-                <code>char</code>
-            </td>
-            <td>`'\u0000'`</td>
-        </tr>
-        <tr>
-            <td>
-                <code>Object</code>
-            </td>
-            <td>`null`</td>
-        </tr>
-    </tbody>
-</table>
+
+| Type                        | Default value |
+|-----------------------------|---------------|
+| `boolean`                   | `false`       |
+| `int` `byte` `short` `long` | `0`           |
+| `float` `double`            | `0.0`         |
+| `char`                      | `'\u0000'`    |
+| `Object`                    | `null`        |
+{:.table}
 
 For example
 


### PR DESCRIPTION
**Proposed change :** use markdown tables instead of html tables for tabular data.
**Why ? :** it's easier to read in the source (and so to maintain) for most cases.
**Limitations :** for tables with a lot of text this is a bit weird. However, few tables are like that, and I think that it's better to have only one table format at this point.

**Other changes :**
 - I noticed and fixed some broken links to anchors
 - I changed the syntax used for footnotes links. The new one is shorter and helps to reduce the problem of tables with really long lines.

WDYT ?