### PR TITLE
Use darker gray for "Improve this page" links

### DIFF
--- a/css/pit.css
+++ b/css/pit.css
@@ -30,11 +30,11 @@ h3 code {
   float: right;
   top: 27px;
   position: relative;
-  color: #ddd;
+  color: #bbb;
 }
 
 .improve a:hover {
-  color: #ccc;
+  color: #aaa;
 }
 
 /* Sections


### PR DESCRIPTION
Use darker gray to make the "improve this page" links a bit more visible.

Current style is on the left, this PR's version is on the right.

![selection_020](https://user-images.githubusercontent.com/6149080/48675016-87535b00-eb53-11e8-965c-ccef564823fa.png)

@hcoles what do you think of this ?