### PR TITLE
Remove the 'Home' link

### DIFF
--- a/_layouts/naked.html
+++ b/_layouts/naked.html
@@ -34,9 +34,6 @@
         <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
               <li>
-                <a href="/">Home</a>
-              </li>
-              <li>
                 <a href="/quickstart">Quickstart</a>
               </li>
               <li>


### PR DESCRIPTION
The 'Home' link is right next to a 'Pitest' link and they both point to the same page.I think we can remove the 'Home' link.

It is pretty standard to click on the top-left-thing (icon, site name, whatever) to come back to the home page.

Below is a screenshot of both versions : the current version is on the left, this PR's version is on the right.
![selection_121](https://user-images.githubusercontent.com/6149080/48775481-73336900-eccd-11e8-8cd6-a816bed02a27.png)


