### PR TITLE
Replace version 1.11.12 by 1.2.0

### DIFF
--- a/quickstart/maven.markdown
+++ b/quickstart/maven.markdown
@@ -46,7 +46,7 @@ By default pitest will mutate all code in your project. You can limit which code
 </plugin>
 ```
 
-If no `targetClasses` are provided in versions before 1.11.12-SNAPSHOT pitest assumes that your classes live in a package matching your projects group id. In versions after 1.11.12 pitest will scan your project to determine which classes are present.
+If no `targetClasses` are provided in versions before 1.2.0, pitest assumes that your classes live in a package matching your projects group id. In 1.2.0 and later verions pitest will scan your project to determine which classes are present.
 
 PIT provides two goals
 
@@ -117,7 +117,7 @@ or
 
 If no targetClasses are supplied pitest will automatically determine what to mutate. 
 
-Before 1.11.12 pitest assumed that all code lives in a package matching the maven group id. After 1.11.12 the classes to mutate are determined by scanning the maven output directory.
+Before 1.2.0 pitest assumed that all code lives in a package matching the maven group id. In 1.2.0 and later versions, the classes to mutate are determined by scanning the maven output directory.
 
 ### targetTests
 


### PR DESCRIPTION
I assume that there is a typo and that `1.11.12` should have been `1.1.12`. Plus, while there was a `1.1.12-SNAPSHOT`, it was released as `1.2.0`. This is consistent with the [1.2.0 release note](https://github.com/hcoles/pitest/releases/tag/1.2.0) which contains [#215 Automatic selection of targetClasses in Maven plugin](https://github.com/hcoles/pitest/issues/215).

So this commit change references to `1.11.12` to `1.2.0`. I hope I got it right :sweat_smile: