### PR TITLE
Fix link to first foot note of comparison page

### DIFF
--- a/pages/java_mutation_testing_systems.markdown
+++ b/pages/java_mutation_testing_systems.markdown
@@ -42,7 +42,7 @@ Jester was the first open source mutation system for Java, but does not appear t
 
 WebSite : [http://jester.sourceforge.net/](http://jester.sourceforge.net/)
 
-Simple Jester is a variant of the original Jester by the same author who describes it as easier to use, but slower <sup id="fnref1">[1]((#fn1))</sup>.
+Simple Jester is a variant of the original Jester by the same author who describes it as easier to use, but slower <sup id="fnref1">[1](#fn1)</sup>.
 
 It appears to no longer be actively developed or supported.
 


### PR DESCRIPTION
69c1f5b5 broke the link by adding a extra layer of parenthesis.
This commit fixes it.