### PR TITLE
Fixing typo in Available mutators

### DIFF
--- a/quickstart/mutators.markdown
+++ b/quickstart/mutators.markdown
@@ -326,7 +326,7 @@ public void someVoidMethod(int i) {
 
 public int foo() {
   int i = 5;
-  doSomething(i);
+  someVoidMethod(i);
   return i;
 }
 ```


### PR DESCRIPTION
Fixing the typo. The method someVoidMethod was not getting called. It was calling doSomething which was not defined.