### PR TITLE
Ensure the footer is always at the bottom of the page

### DIFF
--- a/css/pit.css
+++ b/css/pit.css
@@ -9,9 +9,15 @@
 /* Body and structure
 -------------------------------------------------- */
 
+html {
+  height: 100%;
+}
+
 body {
-  position: relative;
   padding-top: 40px;
+  padding-bottom: 200px;
+  position: relative;
+  min-height: 100%;
 }
 
 strong {
@@ -349,10 +355,14 @@ span.language {
 .footer {
   text-align: center;
   padding: 30px 0;
-  margin-top: 70px;
   border-top: 1px solid #e5e5e5;
   background-color: #f5f5f5;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  left: 0;
 }
+
 .footer p {
   margin-bottom: 0;
   color: #777;

--- a/index.html
+++ b/index.html
@@ -131,9 +131,6 @@ title: PIT Mutation Testing
 
   </div>
 
-
-    <hr class="soften">
-
 </div>
 
 


### PR DESCRIPTION
On pages with few content (like [quickstart](http://localhost:4000/quickstart/)) if the browser window has enough height, the footer is not at the bottom of the page.

This PR changes some CSS rules to ensure it stays at the bottom of the page.

On "quickstart" the change is :

![quickstart-old-vs-new](https://user-images.githubusercontent.com/6149080/52136182-c7e94d80-2647-11e9-8190-222b6019d537.png)

On "about", chosen to represent pages that had already enough content to push the footer down, no difference is visible :

![about-old-vs-new](https://user-images.githubusercontent.com/6149080/52136264-f36c3800-2647-11e9-805e-9f4d39728f27.png)

On the landing page, I had some trouble getting something nice at the bottom of the page. My changes don't play well with the last `<hr class=soften>`. But I don't think it is _that_ important in the layout, so I tried removing it and it looks fine by me. I can try to make it work with the `hr` if needed.

![landing-page-old-vs-new](https://user-images.githubusercontent.com/6149080/52136488-7ab9ab80-2648-11e9-8436-de98263a1cc2.png)
