### PR TITLE
#66 Ensure links to anchor are not hidden by the navbar

### DIFF
--- a/css/pit.css
+++ b/css/pit.css
@@ -44,6 +44,21 @@ a:hover {
   border-color: #285e8e;
 }
 
+/* Anchors
+-------------------------------------------------- */
+
+/*
+ Generates an invisible dom element right before the target anchor.
+ This element has a height great enough for the navbar to not hide the actual anchor we want to show.
+ Got the idea from : https://stackoverflow.com/a/28824157/9924986
+ */
+:target::before {
+  content: "";
+  display: inline-block;
+  height: 75px;      /* empiric value matching the navbar plus a small margin */
+  margin: -75px 0 0; /* negation of the height */
+}
+
 /* "Improve this page" links
 -------------------------------------------------- */
 .improve a {


### PR DESCRIPTION
When clicking on links to anchors, the value we wanted to display was often hidden by the navbar. (see https://github.com/hcoles/pitest-site/issues/66). Annoying, right ?

This PR uses some CSS wizardry to offset it just the right amount for the target to be visible.