### PR TITLE
Remove outdated paragraph about mutators

### DIFF
--- a/quickstart/mutators.markdown
+++ b/quickstart/mutators.markdown
@@ -17,11 +17,6 @@ The operators are largely designed to be **stable** (i.e not be too easy to dete
 
 # Available mutators
 
-We'll briefly describe the available mutators in the following sections. See the [test cases](#TEST_CASES) for
-more detailed examples.
-
-Here is the list of available mutators:
-
 (*activated by default*)
 - [Conditionals Boundary Mutator](#CONDITIONALS_BOUNDARY)
 - [Increments Mutator](#INCREMENTS)


### PR DESCRIPTION
The paragraph following the "Available Mutators" title was outdated ; contrary to what it said, mutators description is now quite complete and the "test cases" it links to is no more.

I removed the whole paragraph since the title in itself says enough.