### PR TITLE
Update muJava source code reference

### DIFF
--- a/pages/java_mutation_testing_systems.markdown
+++ b/pages/java_mutation_testing_systems.markdown
@@ -24,7 +24,7 @@ WebSite : [http://cs.gmu.edu/offutt/mujava/](http://cs.gmu.edu/~offutt/mujava/)
  
 It is the result of a collaboration between two universities, Korea Advanced Institute of Science and Technology (KAIST) in S. Korea and George Mason University in the USA. 
 
-Source code is available on a limited basis to researchers in mutation analysis.
+As of 2015, the source code has been made available at https://cs.gmu.edu/~offutt/mujava/
 
 According to the website :
 


### PR DESCRIPTION
According to their website, https://cs.gmu.edu/~offutt/mujava/, they made the source code available a couple of years ago at https://github.com/jeffoffutt/muJava