### PR TITLE
Mention FLOGCALL and EXPORT features

### DIFF
--- a/pages/faq.markdown
+++ b/pages/faq.markdown
@@ -212,7 +212,9 @@ henry@pitest.org
 
 ## Could I accidentally release mutated code if I use PIT?
 
-No. The mutations that PIT generates are held in memory and never written to disk. 
+No. The mutations that PIT generates are held in memory and never written to disk,
+except if explicitly enabled using the `EXPORT` feature. But even then they are
+only dumped inside the report directory and should not be released accidentally.
 
 ## Where are snapshot releases uploaded to?
 

--- a/quickstart/basic_concepts.markdown
+++ b/quickstart/basic_concepts.markdown
@@ -82,8 +82,8 @@ if ( i > 1 ) {
 
 A common example are mutations to code related to logging or debug. Most teams are not interested 
 in testing these. PIT avoids generating this type of equivalent mutation by not generating mutations
-for lines that contain a call to common logging frameworks (this list of frameworks is configurable, so
-mutation of logging statements can be enabled by configuring a list containing only a non-existent class).
+for lines that contain a call to common logging frameworks (this list of frameworks is configurable,
+to enable mutation of logging statements disable the feature `FLOGCALL`).
       
 ## Running the tests
 

--- a/quickstart/commandline.markdown
+++ b/quickstart/commandline.markdown
@@ -126,6 +126,8 @@ packages as follows
 * org.slf4j
 * org.apache.commons.logging
 
+If the feature `FLOGCALL` is disabled, this parameter is ignored and logging calls are also mutated.
+
 ### \--verbose
 
 Output verbose logging. Defaults to off/false.

--- a/quickstart/maven.markdown
+++ b/quickstart/maven.markdown
@@ -204,6 +204,7 @@ So, the configuration section must look like:
 </avoidCallsTo>
 ```
 
+If the feature `FLOGCALL` is disabled, this parameter is ignored and logging calls are also mutated.
 
 ### verbose
 


### PR DESCRIPTION
* Mention feature FLOGCALL to enable logging statement mutation instead of configuring an invalid class
* Mention the possibility to dump the mutants to not give the impression dumping the mutants is impossible