### PR TITLE
Use correct mutator group name + typo fix

### DIFF
--- a/quickstart/mutators.markdown
+++ b/quickstart/mutators.markdown
@@ -19,9 +19,9 @@ The operators are largely designed to be **stable** (i.e not be too easy to dete
 
 # Available mutators and groups
 
-The following table list available mutators and wheter or not they are part of a group :
+The following table list available mutators and whether or not they are part of a group :
 
-| Mutators                                                                | "DEFAULT" group| "NEW_DEFAULTS" group | "STRONGER" group                | "ALL" group|
+| Mutators                                                                | "DEFAULTS" group| "NEW_DEFAULTS" group | "STRONGER" group                | "ALL" group|
 |-------------------------------------------------------------------------|:--------------:|:--------------------:|:-------------------------------:|:----------:|
 | [Conditionals Boundary](#CONDITIONALS_BOUNDARY)                         | yes            | yes                  | yes                             | yes        |
 | [Increments](#INCREMENTS)                                               | yes            | yes                  | yes                             | yes        |


### PR DESCRIPTION
While using PIT, I had tried the `DEFAULT` mutator group when extending the mutators for my project and it came back as being an unknown group. Looking into the [Mutator class source code](https://github.com/hcoles/pitest/blob/master/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/config/Mutator.java), it looks like the group is actually named `DEFAULTS` not `DEFAULT`.

This PR fixes this issue in the documentation as well as another unrelated typo.