### PR TITLE
removing broken link

### DIFF
--- a/pages/faq.markdown
+++ b/pages/faq.markdown
@@ -220,10 +220,6 @@ only dumped inside the report directory and should not be released accidentally.
 
 [https://oss.sonatype.org/content/repositories/snapshots/org/pitest/](https://oss.sonatype.org/content/repositories/snapshots/org/pitest/)
 
-## Does PIT work with Sonar?
-
-Alexandre Victoor maintains a Sonar plugin. [PIT Sonar plugin](http://docs.codehaus.org/display/SONAR/Pitest)
-
 ## How do I use PIT with Gradle?
 
 See [PIT Gradle plugin](http://gradle-pitest-plugin.solidsoft.info/)

--- a/pages/links.markdown
+++ b/pages/links.markdown
@@ -9,9 +9,8 @@ permalink: /links/
 
 * Marcin Zajączkowski maintains a Gradle plugin. [PIT Gradle plugin](http://gradle-pitest-plugin.solidsoft.info/)
 * Phil Glover maintains an Eclipse plugin. [Pitclipse](https://github.com/philglover/pitclipse)
-* Alexandre Victoor maintains a Sonar plugin. [PIT Sonar plugin](http://docs.codehaus.org/display/SONAR/Pitest)
 * Michal Jedynak maintains an Intellij plugin. [PIT intellij plugin](https://plugins.jetbrains.com/plugin/7119-pit-mutation-testing-idea-plugin)
-* Oscar Luis Vera Perez maitains Descartes, an extreme mutation engine. [pit-descartes](http://github.com/STAMP-project/pitest-descartes)
+* Oscar Luis Vera Perez maintains Descartes, an extreme mutation engine. [pit-descartes](http://github.com/STAMP-project/pitest-descartes)
 * Caroline Landry maintains PitMP, a Maven plugin to run PIT on multi-module projects. [pitmp-maven-plugin](http://github.com/STAMP-project/pitmp-maven-plugin)
 
 ## Videos


### PR DESCRIPTION
Links to "PIT Sonar plugin" are broken since codehaus.org has been decommissioned.