### PR TITLE
[#759] Added a preview feature example to jvmArgs section

### DIFF
--- a/quickstart/maven.markdown
+++ b/quickstart/maven.markdown
@@ -242,6 +242,14 @@ For example when running on OpenJDK 7 the it is sometimes necessary to disable t
 </jvmArgs>
 ```
 
+Or to use a [preview feature](https://docs.oracle.com/en/java/javase/14/language/preview-language-and-vm-features.html) from JDK:
+
+```xml
+<jvmArgs>
+    <jvmArg>--enable-preview</jvmArg>
+</jvmArgs>
+```
+
 ### jvm
 
 The path to tha java executable to be used to launch test with. If none is supplied defaults to the one pointed to by ```JAVA_HOME```.


### PR DESCRIPTION
This example is important because it will prevent a following issue:

`12:56:50 PIT >> INFO : MINION : 12:56:50 PIT >> WARNING : Could not load com.mycompany.Main Preview features are not enabled for com/mycompany/Main (class file version 58.65535). Try running with '--enable-preview'`