### PR TITLE
Adding some hint or warning about cost of ownership

### DIFF
--- a/pages/quickstart.markdown
+++ b/pages/quickstart.markdown
@@ -6,10 +6,10 @@ permalink: /quickstart/
 
 # Quickstart
 
-Out of the box PIT can be launched from the command line, ant or maven. Third party
+Out of the box Pitest can be launched from the command line, ant or maven. Third party
 components provide integration with Gradle, Eclipse, IntelliJ and others (see the [links](/links "links") section for details).
 
-The impatient can jump straight to the section for their chosen build tool - it may however be helpful to read the basic concepts section first.
+The impatient can jump straight to the section for their chosen build tool - it may however be helpful to read the basic concepts section first. Mutation tests - like other quality measures - are associated with costs: The cost of execution time (CPU) for projects with Pitest are noticeably higher than without. Depending on the size of the project, the number of tests and the hardware you are using, mutation testing can take seconds, minutes or even hours. Aside from basic testing or ongoing reviews using the \*scm goals, it's always a good idea to run Pitest as part of your CI build.
 
 ## Getting started
 


### PR DESCRIPTION
Running pitest comes with some cost: cost of CPU we could make this a little bit more transparent and guide users to use mutation testing as part of their CI process.

fixes #35