### PR TITLE
Update basic_concepts.markdown -- Clarifying definitions for readability

### DIFF
--- a/quickstart/basic_concepts.markdown
+++ b/quickstart/basic_concepts.markdown
@@ -104,7 +104,9 @@ For each mutation PIT will report one of the following outcomes
 * **Memory error**
 * **Run error**
 
-**Killed** and **Lived** are self explanatory.
+**Killed** means a test caught the mutation successfully.
+
+**Lived** means the mutation was not detected by the covering test.
 
 **No coverage** is the same as **Lived** except there were no tests that exercised the line of code where the mutation was created.
 


### PR DESCRIPTION
**Killed** and **lived** are easy concepts, once you have used Pitest. But to say that they are self-explanatory on the site where these words should be defined confused me as a new user.

I just explained the words instead of supposing any knowledge from the reader.